### PR TITLE
created layout model

### DIFF
--- a/Server/models/layoutModel.ts
+++ b/Server/models/layoutModel.ts
@@ -1,0 +1,59 @@
+import {Schema,model,Document} from 'mongoose'
+
+interface FaqItem extends Document{
+    question:string;
+    answer:string;
+}
+
+interface Category extends Document{
+    title:string;
+}
+
+interface BannerImage extends Document{
+    public_id:string;
+    url:string;
+}
+
+interface Layout extends Document{
+    type:string;
+    faq:FaqItem[];
+    categories:Category[];
+    banner:{
+        image:BannerImage;
+        title:string;
+        subTitle:string;
+    }
+}
+
+const faqSchema=new Schema <FaqItem> ({
+    question:{type:String},
+    answer:{type:String},
+
+})
+
+const CategorySchema=new Schema <Category>({
+  title:{type:String},
+})
+
+const BannerImageSchema = new Schema <BannerImage>({
+    public_id:{type:String},
+    url:{type:String}
+})
+
+const LayoutSchema = new Schema <Layout>({
+    type:{type:String},
+    faq:[faqSchema],
+    categories:[CategorySchema],
+    banner:{
+        image:BannerImageSchema,
+        title:{type:String},
+        subTitle:{type:String}
+    }
+
+})
+
+const LayoutModel=model<Layout>('Layout',LayoutSchema)
+
+export default LayoutModel
+
+


### PR DESCRIPTION
 defines Mongoose schemas and a model for managing layout data in a web application. It includes interfaces for FAQ items, categories, and banner images, with corresponding schemas embedded within the layout schema. Finally, a Mongoose model named 'Layout' is created based on the defined schema.